### PR TITLE
feat: add scene qr login

### DIFF
--- a/common/login-session-manager.go
+++ b/common/login-session-manager.go
@@ -1,0 +1,204 @@
+package common
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type LoginSessionStatus string
+
+const (
+	SessionStatusPending LoginSessionStatus = "pending"
+	SessionStatusSuccess LoginSessionStatus = "success"
+	SessionStatusExpired LoginSessionStatus = "expired"
+)
+
+type WeChatUserInfo struct {
+	OpenID string `json:"openid"`
+}
+
+type LoginSession struct {
+	LoginToken string             `json:"login_token"` // 前端查询令牌
+	SceneID    string             `json:"scene_id"`    // 微信场景值
+	Status     LoginSessionStatus `json:"status"`      // 会话状态
+	WeChatID   string             `json:"wechat_id"`   // 微信用户ID
+	AuthCode   string             `json:"auth_code"`   // 授权给clinx的代码
+	UserInfo   *WeChatUserInfo    `json:"user_info"`   // 用户详细信息
+	CreatedAt  time.Time          `json:"created_at"`  // 创建时间
+	ExpiredAt  time.Time          `json:"expired_at"`  // 过期时间
+}
+
+type LoginSessionManager struct {
+	sessions map[string]*LoginSession // key: login_token
+	scenes   map[string]string        // key: scene_id, value: login_token
+	mutex    sync.RWMutex
+	cleanup  *time.Ticker
+}
+
+var sessionManager = &LoginSessionManager{
+	sessions: make(map[string]*LoginSession),
+	scenes:   make(map[string]string),
+	cleanup:  time.NewTicker(1 * time.Minute),
+}
+
+func init() {
+	go sessionManager.startCleanup()
+}
+
+func (m *LoginSessionManager) generateLoginToken() string {
+	bytes := make([]byte, 16)
+	rand.Read(bytes)
+	return hex.EncodeToString(bytes)
+}
+
+func (m *LoginSessionManager) generateSceneID() string {
+	timestamp := time.Now().Unix()
+	randomBytes := make([]byte, 8)
+	rand.Read(randomBytes)
+	randomStr := hex.EncodeToString(randomBytes)
+	return fmt.Sprintf("login_%d_%s", timestamp, randomStr)
+}
+
+func (m *LoginSessionManager) CreateSession() *LoginSession {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	loginToken := m.generateLoginToken()
+	sceneID := m.generateSceneID()
+	authCode := m.generateLoginToken() // 生成授权码
+
+	session := &LoginSession{
+		LoginToken: loginToken,
+		SceneID:    sceneID,
+		Status:     SessionStatusPending,
+		AuthCode:   authCode,
+		CreatedAt:  time.Now(),
+		ExpiredAt:  time.Now().Add(10 * time.Minute), // 10分钟过期
+	}
+
+	m.sessions[loginToken] = session
+	m.scenes[sceneID] = loginToken
+
+	SysLog(fmt.Sprintf("Created login session: token=%s, scene=%s", loginToken, sceneID))
+	return session
+}
+
+func (m *LoginSessionManager) GetSession(loginToken string) *LoginSession {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	session, exists := m.sessions[loginToken]
+	if !exists {
+		return nil
+	}
+
+	if session.ExpiredAt.Before(time.Now()) {
+		delete(m.sessions, loginToken)
+		delete(m.scenes, session.SceneID)
+		return nil
+	}
+
+	return session
+}
+
+func (m *LoginSessionManager) GetSessionByScene(sceneID string) *LoginSession {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	loginToken, exists := m.scenes[sceneID]
+	if !exists {
+		return nil
+	}
+
+	session, exists := m.sessions[loginToken]
+	if !exists || session.ExpiredAt.Before(time.Now()) {
+		delete(m.scenes, sceneID)
+		if exists {
+			delete(m.sessions, loginToken)
+		}
+		return nil
+	}
+
+	return session
+}
+
+func (m *LoginSessionManager) UpdateSessionByScene(sceneID, wechatID string, userInfo *WeChatUserInfo) bool {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	loginToken, exists := m.scenes[sceneID]
+	if !exists {
+		return false
+	}
+
+	session, sessionExists := m.sessions[loginToken]
+	if !sessionExists {
+		return false
+	}
+
+	session.WeChatID = wechatID
+	session.UserInfo = userInfo
+	session.Status = SessionStatusSuccess
+
+	SysLog(fmt.Sprintf("Updated login session: wechat_id=%s, status=success", wechatID))
+	return true
+}
+
+func (m *LoginSessionManager) startCleanup() {
+	for range m.cleanup.C {
+		m.mutex.Lock()
+		now := time.Now()
+
+		for loginToken, session := range m.sessions {
+			if session.ExpiredAt.Before(now) {
+				session.Status = SessionStatusExpired
+				delete(m.sessions, loginToken)
+				delete(m.scenes, session.SceneID)
+			}
+		}
+
+		SysLog(fmt.Sprintf("Cleanup completed, active sessions: %d", len(m.sessions)))
+		m.mutex.Unlock()
+	}
+}
+
+func (m *LoginSessionManager) GetActiveSessionCount() int {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	return len(m.sessions)
+}
+
+func FindWeChatIDByAuthCode(c *gin.Context) (string, error) {
+	code := c.Query("code")
+	if code == "" {
+		return "", fmt.Errorf("无效的参数")
+	}
+	weChatAppID := sessionManager.findWeChatIDByAuthCode(code)
+	if weChatAppID == "" {
+		return "", fmt.Errorf("授权码无效或已过期")
+	}
+	return weChatAppID, nil
+}
+
+func (m *LoginSessionManager) findWeChatIDByAuthCode(authCode string) string {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	for _, session := range m.sessions {
+		if session.AuthCode == authCode && session.Status == SessionStatusSuccess {
+			return session.WeChatID
+		}
+	}
+
+	return ""
+}
+
+// 导出全局访问器
+func GetSessionManager() *LoginSessionManager {
+	return sessionManager
+}

--- a/common/wechat-message.go
+++ b/common/wechat-message.go
@@ -1,6 +1,10 @@
 package common
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+)
 
 type WeChatMessageRequest struct {
 	XMLName      xml.Name `xml:"xml"`
@@ -12,6 +16,10 @@ type WeChatMessageRequest struct {
 	MsgId        int64    `xml:"MsgId"`
 	MsgDataId    int64    `xml:"MsgDataId"`
 	Idx          int64    `xml:"Idx"`
+	// 事件相关字段
+	Event    string `xml:"Event,omitempty"`
+	EventKey string `xml:"EventKey,omitempty"`
+	Ticket   string `xml:"Ticket,omitempty"`
 }
 
 type WeChatMessageResponse struct {
@@ -24,10 +32,68 @@ type WeChatMessageResponse struct {
 }
 
 func ProcessWeChatMessage(req *WeChatMessageRequest, res *WeChatMessageResponse) {
-	switch req.Content {
-	case "验证码":
-		code := GenerateAllNumberVerificationCode(6)
-		RegisterWeChatCodeAndID(code, req.FromUserName)
-		res.Content = code
+	SysLog(fmt.Sprintf("Received WeChat message: type=%s, from=%s, event=%s, key=%s, content=%s",
+		req.MsgType, req.FromUserName, req.Event, req.EventKey, req.Content))
+
+	switch {
+	case req.MsgType == "event" && (req.Event == "subscribe" || req.Event == "SCAN"):
+		handleQRCodeScanEvent(req, res)
+
+	case req.MsgType == "text":
+		switch req.Content {
+		case "验证码":
+			handleVerificationCode(req, res)
+		default:
+			res.Content = "发送「验证码」获取登录验证码"
+		}
+
+	default:
+		res.Content = "欢迎使用！发送「验证码」获取登录验证码"
 	}
+}
+
+func handleQRCodeScanEvent(req *WeChatMessageRequest, res *WeChatMessageResponse) {
+	var sceneID string
+
+	if req.Event == "subscribe" && strings.HasPrefix(req.EventKey, "qrscene_") {
+		sceneID = strings.TrimPrefix(req.EventKey, "qrscene_")
+		res.Content = "欢迎关注！登录成功，请返回网页继续操作"
+
+	} else if req.Event == "SCAN" {
+		sceneID = req.EventKey
+		res.Content = "登录成功，请返回网页继续操作"
+
+	} else {
+		res.Content = "欢迎关注！发送「验证码」获取登录验证码，或使用扫码登录功能"
+		return
+	}
+
+	session := GetSessionManager().GetSessionByScene(sceneID)
+	if session == nil {
+		SysLog(fmt.Sprintf("No session found for scene: %s", sceneID))
+		if req.Event == "subscribe" {
+			res.Content = "欢迎关注！二维码可能已过期，请重新生成"
+		}
+		return
+	}
+
+	userInfo := &WeChatUserInfo{
+		OpenID: req.FromUserName,
+	}
+
+	success := GetSessionManager().UpdateSessionByScene(sceneID, req.FromUserName, userInfo)
+	if success {
+		SysLog(fmt.Sprintf("Successfully updated login session: scene=%s, wechat=%s",
+			sceneID, req.FromUserName))
+	} else {
+		SysLog(fmt.Sprintf("Failed to update login session: scene=%s", sceneID))
+		res.Content = "登录失败，请重新扫码"
+	}
+}
+
+func handleVerificationCode(req *WeChatMessageRequest, res *WeChatMessageResponse) {
+	code := GenerateAllNumberVerificationCode(6)
+	RegisterWeChatCodeAndID(code, req.FromUserName)
+	res.Content = code
+	SysLog(fmt.Sprintf("Generated verification code: %s for user: %s", code, req.FromUserName))
 }

--- a/controller/wechat-qrcode.go
+++ b/controller/wechat-qrcode.go
@@ -1,0 +1,114 @@
+package controller
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"wechat-server/common"
+
+	"github.com/gin-gonic/gin"
+)
+
+type CreateQRCodeResponse struct {
+	Success bool `json:"success"`
+	Data    struct {
+		SceneID       string `json:"scene_id"`
+		QRCodeURL     string `json:"qrcode_url"`
+		LoginToken    string `json:"login_token"`
+		ExpireSeconds int    `json:"expire_seconds"`
+	} `json:"data"`
+	Message string `json:"message"`
+}
+
+type WeChatQRCodeRequest struct {
+	ExpireSeconds int    `json:"expire_seconds"`
+	ActionName    string `json:"action_name"`
+	ActionInfo    struct {
+		Scene struct {
+			SceneStr string `json:"scene_str"`
+		} `json:"scene"`
+	} `json:"action_info"`
+}
+
+type WeChatQRCodeResponse struct {
+	Ticket        string `json:"ticket"`
+	ExpireSeconds int    `json:"expire_seconds"`
+	URL           string `json:"url"`
+	ErrorCode     int    `json:"errcode,omitempty"`
+	ErrorMessage  string `json:"errmsg,omitempty"`
+}
+
+func CreateLoginQRCode(c *gin.Context) {
+	session := common.GetSessionManager().CreateSession()
+	if session == nil {
+		c.JSON(http.StatusInternalServerError, CreateQRCodeResponse{
+			Success: false,
+			Message: "创建登录会话失败",
+		})
+		return
+	}
+	accessToken := common.GetAccessToken()
+	if accessToken == "" {
+		c.JSON(http.StatusInternalServerError, CreateQRCodeResponse{
+			Success: false,
+			Message: "获取微信访问令牌失败",
+		})
+		return
+	}
+	qrReq := WeChatQRCodeRequest{
+		ExpireSeconds: 600, // 10分钟
+		ActionName:    "QR_STR_SCENE",
+	}
+	qrReq.ActionInfo.Scene.SceneStr = session.SceneID
+
+	qrReqJSON, err := json.Marshal(qrReq)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, CreateQRCodeResponse{
+			Success: false,
+			Message: "构建二维码请求失败",
+		})
+		return
+	}
+	url := fmt.Sprintf("https://api.weixin.qq.com/cgi-bin/qrcode/create?access_token=%s", accessToken)
+	resp, err := http.Post(url, "application/json", bytes.NewBuffer(qrReqJSON))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, CreateQRCodeResponse{
+			Success: false,
+			Message: "调用微信API失败: " + err.Error(),
+		})
+		return
+	}
+	defer resp.Body.Close()
+
+	var qrResp WeChatQRCodeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&qrResp); err != nil {
+		c.JSON(http.StatusInternalServerError, CreateQRCodeResponse{
+			Success: false,
+			Message: "解析微信响应失败: " + err.Error(),
+		})
+		return
+	}
+	if qrResp.ErrorCode != 0 {
+		c.JSON(http.StatusInternalServerError, CreateQRCodeResponse{
+			Success: false,
+			Message: fmt.Sprintf("微信API错误: %s", qrResp.ErrorMessage),
+		})
+		return
+	}
+	qrcodeURL := fmt.Sprintf("https://mp.weixin.qq.com/cgi-bin/showqrcode?ticket=%s", qrResp.Ticket)
+	response := CreateQRCodeResponse{
+		Success: true,
+		Message: "二维码创建成功",
+	}
+	response.Data.SceneID = session.SceneID
+	response.Data.QRCodeURL = qrcodeURL
+	response.Data.LoginToken = session.LoginToken
+	response.Data.ExpireSeconds = qrResp.ExpireSeconds
+
+	c.JSON(http.StatusOK, response)
+
+	common.SysLog(fmt.Sprintf("Created login QRCode: scene=%s, token=%s, ticket=%s",
+		session.SceneID, session.LoginToken, qrResp.Ticket))
+}

--- a/controller/wechat-status.go
+++ b/controller/wechat-status.go
@@ -1,0 +1,53 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+
+	"wechat-server/common"
+
+	"github.com/gin-gonic/gin"
+)
+
+type LoginStatusResponse struct {
+	Success bool `json:"success"`
+	Data    struct {
+		Status     string                 `json:"status"`
+		WeChatUser *common.WeChatUserInfo `json:"wechat_user,omitempty"`
+		AuthCode   string                 `json:"auth_code,omitempty"`
+	} `json:"data"`
+	Message string `json:"message"`
+}
+
+func GetLoginStatus(c *gin.Context) {
+	loginToken := c.Query("login_token")
+	if loginToken == "" {
+		c.JSON(http.StatusBadRequest, LoginStatusResponse{
+			Success: false,
+			Message: "缺少login_token参数",
+		})
+		return
+	}
+	session := common.GetSessionManager().GetSession(loginToken)
+	if session == nil {
+		c.JSON(http.StatusOK, LoginStatusResponse{
+			Success: false,
+			Message: "登录令牌无效或已过期",
+		})
+		return
+	}
+	response := LoginStatusResponse{
+		Success: true,
+		Message: "查询成功",
+	}
+
+	response.Data.Status = string(session.Status)
+	if session.Status == common.SessionStatusSuccess && session.UserInfo != nil {
+		response.Data.WeChatUser = session.UserInfo
+		response.Data.AuthCode = session.AuthCode
+	}
+
+	c.JSON(http.StatusOK, response)
+
+	common.SysLog(fmt.Sprintf("Login status query: token=%s, status=%s", loginToken, session.Status))
+}

--- a/controller/wechat.go
+++ b/controller/wechat.go
@@ -4,12 +4,13 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"encoding/xml"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"sort"
 	"strings"
 	"time"
 	"wechat-server/common"
+
+	"github.com/gin-gonic/gin"
 )
 
 type wechatResponse struct {
@@ -72,6 +73,21 @@ func GetUserIDByCode(c *gin.Context) {
 		"message": "",
 		"success": true,
 		"data":    id,
+	})
+	return
+}
+
+func GetUserID(c *gin.Context) {
+	wechatID, err := common.FindWeChatIDByAuthCode(c)
+	if err != nil {
+		// 如果新的登录方式失败，尝试使用旧的验证码登录方式
+		GetUserIDByCode(c)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"message": "",
+		"success": true,
+		"data":    wechatID,
 	})
 	return
 }

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -61,7 +61,9 @@ func SetApiRouter(router *gin.Engine) {
 		wechatRoute.Use(middleware.AdminAuth(), middleware.TokenOnlyAuth())
 		{
 			wechatRoute.GET("/access_token", controller.GetAccessToken)
-			wechatRoute.GET("/user", controller.GetUserIDByCode)
+			wechatRoute.GET("/user", controller.GetUserID)
+			wechatRoute.POST("/create_login_qrcode", controller.CreateLoginQRCode)
+			wechatRoute.GET("/login_status", controller.GetLoginStatus)
 		}
 	}
 }


### PR DESCRIPTION
当前的微信扫码后需要在公众号发送`验证码`,并且手动输入返回的验证码,才可以登录, 比较繁琐
本pr通过微信生成二维码可以带自定义场景值的方式, 通过每次生成不同的场景值来代替验证码实现用户扫码成功后就可以自动登录
原理:
生成带场景值二维码-->用户扫码-->接收微信通知:服务端场景值和openid对应-->前端轮询是否扫码成功-->成功登录